### PR TITLE
feat: add socket service with Dockerfile and compose config

### DIFF
--- a/Dockerfile.socket
+++ b/Dockerfile.socket
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o socket-server ./cmd/socket/main.go
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/socket-server ./socket-server
+EXPOSE 8081
+CMD ["./socket-server"] 

--- a/docker-compose.socket.yml
+++ b/docker-compose.socket.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  socket:
+    build:
+      context: .
+      dockerfile: Dockerfile.socket
+    container_name: dev-socket
+    command: go run cmd/socket/main.go
+    ports:
+      - "8081:8081"


### PR DESCRIPTION
Add a new Dockerfile.socket to build the socket server binary using
a multi-stage build for a smaller final image. Introduce a new
docker-compose.socket.yml file to define the socket service, enabling
easy local development and testing by exposing port 8081. This setup
improves modularity and streamlines running the socket server in a
containerized environment.