### PR TITLE
feat(socket): add nginx reverse proxy for websocket support

### DIFF
--- a/docker-compose.socket.yml
+++ b/docker-compose.socket.yml
@@ -8,3 +8,13 @@ services:
     command: go run cmd/socket/main.go
     ports:
       - "8081:8081"
+
+  nginx:
+    image: nginx:alpine
+    container_name: dev-nginx-socket
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.socket.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - socket

--- a/nginx.socket.conf
+++ b/nginx.socket.conf
@@ -1,0 +1,19 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    location /ws/orders {
+        proxy_pass             http://socket:8081;
+        proxy_http_version     1.1;
+        proxy_set_header       Upgrade           $http_upgrade;
+        proxy_set_header       Connection        $connection_upgrade;
+        proxy_set_header       Host              $host;
+        proxy_set_header       X-Real-IP         $remote_addr;
+        proxy_set_header       X-Forwarded-For   $proxy_add_x_forwarded_for;
+    }
+} 


### PR DESCRIPTION
Add an nginx configuration to proxy websocket connections on /ws/orders
to the socket service running on port 8081. Update docker-compose to
include the nginx container, exposing port 80 and linking it to the
socket service. This enables proper handling of websocket upgrade headers
and improves connection management for real-time features.