### PR TITLE
chore(docker): update Go version and improve module handling

### DIFF
--- a/Dockerfile.socket
+++ b/Dockerfile.socket
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24.3-alpine AS builder
 WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
+COPY go.mod ./
+RUN go mod tidy
 COPY . .
 RUN go build -o socket-server ./cmd/socket/main.go
 


### PR DESCRIPTION
Upgrade base image to golang:1.24.3-alpine for latest features and
security patches. Replace 'go mod download' with 'go mod tidy' to
ensure module dependencies are clean and up to date during build.